### PR TITLE
feat(orchestrator): #24 #25 - Job state tracking and step runner

### DIFF
--- a/crates/ferri-automation/src/flow.rs
+++ b/crates/ferri-automation/src/flow.rs
@@ -34,6 +34,26 @@ pub struct StepUpdate {
     pub status: StepStatus,
     pub output: Option<String>,
 }
+
+#[derive(Clone, Debug)]
+pub enum JobStatus {
+    Pending,
+    Running,
+    Succeeded,
+    Failed(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct JobUpdate {
+    pub job_id: String,
+    pub status: JobStatus,
+}
+
+#[derive(Clone, Debug)]
+pub enum Update {
+    Job(JobUpdate),
+    Step(StepUpdate),
+}
 // ---
 
 // --- Top-Level Schema ---


### PR DESCRIPTION
## Summary

Implements job-level state tracking and a proper step runner for the L2 flow orchestration engine. These are foundational pieces for the runtime execution chain.

Closes #24
Closes #25

---

## Changes

### Issue #24: Job State Tracking

Added comprehensive state management for jobs with four states: Pending, Running, Succeeded, Failed.

**Implementation:**
- `JobStatus` enum with all four states
- `JobUpdate` struct for job-level status updates  
- Unified `Update` enum to handle both job and step updates via single channel
- Job status updates sent at key orchestration points:
  * **Pending**: When wave starts (all jobs in wave marked pending)
  * **Running**: When job thread begins execution
  * **Succeeded**: When job completes successfully
  * **Failed**: When job returns error or thread panics
- All `StepUpdate` sends wrapped in `Update::Step` for unified handling

**Files Modified:**
- `crates/ferri-automation/src/flow.rs`: Added JobStatus, JobUpdate, Update enum
- `crates/ferri-automation/src/orchestrator.rs`: Updated to send job status updates
- Added `test_job_state_tracking` test

---

### Issue #25: Step Runner Implementation

Refactored step execution to use direct command execution instead of the background job system.

**Why the change:**
The previous implementation used the L1 background job system (designed for long-running AI calls) to execute flow steps. This was:
- Unnecessarily complex (polling, persistence, job IDs)
- Asynchronous when steps should run synchronously within jobs
- Made output association with steps awkward

**New Implementation:**
- Direct synchronous execution using `Command::output()`
- Sets working directory to `base_path`
- Captures and combines stdout/stderr
- Reports exit codes on failure
- Properly associates outputs with step names in evaluation context
- Removed dependencies on jobs module, PreparedCommand, Duration

**Benefits:**
- Correct flow semantics (steps run synchronously in job)
- Simpler, more predictable execution
- Better error messages with exit codes
- Proper foundation for #29 (ferri-runtime set-output parsing)

**Files Modified:**
- `crates/ferri-automation/src/orchestrator.rs`: Rewrote `execute_run_step` function

---

## Testing

- All 3 orchestrator tests pass
- All 10 library tests pass
- Clean build with no errors (only pre-existing dead_code warning)

## Next Steps

These changes enable the next issues in the runtime chain:
- #29: `ferri-runtime set-output` command (can now parse from step output)
- #31, #32: Workspace implementation (can now mount into step execution)