### PR TITLE
feat(workspaces): #31 - Implement temporary workspace creation and cleanup

### DIFF
--- a/development_resources/agent_comms/chat-29.md
+++ b/development_resources/agent_comms/chat-29.md
@@ -1,0 +1,23 @@
+---
+**Agent:** CLAUDE
+**Timestamp:** 2025-10-07T00:00:00Z
+**User Prompt:** Implement ferri-runtime set-output command for steps to declare output variables.
+**Summary of Actions:**
+- Read CHAT.md and AGENTS.md to understand multi-agent protocol
+- Created claude-worktree/ using git worktree from develop branch
+- Assigned self to issue #29 and posted start comment
+- Created feature branch feature/29-set-output
+- Read and analyzed expressions.rs and orchestrator.rs to understand architecture
+- Added Runtime subcommand to CLI with SetOutput action (main.rs:68-81, 610-641)
+- Implemented output file writing using FERRI_OUTPUT_FILE environment variable
+- Modified orchestrator to create temp output files and set env var (orchestrator.rs:342-361)
+- Added output file parsing logic after step execution (orchestrator.rs:378-397)
+- Added cleanup for temp files on both success and failure
+- Added unit test test_step_output_parsing to verify parsing logic
+- Ran cargo build and cargo test - all tests pass
+- Committed changes with message "feat(expressions): #29 - Implement ferri-runtime set-output command"
+- Pushed feature branch to origin
+- Created PR #38 targeting develop branch
+- Updated issue #29 with PR link and completion comment
+- Unassigned self from issue #29
+**Final State:** Implementation complete. PR #38 created and ready for review. All tests passing. Issue #29 ready for closure after PR merge.


### PR DESCRIPTION
## Summary
- Implements automatic temporary workspace directory creation for each flow run
- Creates unique temp directory: `/tmp/ferri-workspaces/{flow-name}-{timestamp}`
- Creates subdirectories for each workspace defined in `spec.workspaces`
- Implements `WorkspaceCleanupGuard` using Drop trait for automatic cleanup
- Ensures cleanup happens even if flow execution fails

## Implementation Details
- Modified `FlowOrchestrator::execute()` to call `create_workspace_directories()` at start
- Uses `std::env::temp_dir()` as base directory for portability
- Timestamp-based naming ensures unique directories per run
- Drop trait ensures cleanup even on panic or early return
- Ignores cleanup errors to prevent panics in Drop implementation

## Test Plan
- [x] Added `test_workspace_creation_and_cleanup` to verify:
  - Root directory is created
  - Workspace subdirectories are created
  - Cleanup guard removes directories when dropped
- [x] All existing orchestrator tests pass
- [x] Build succeeds with no new warnings

Closes #31