### PR TITLE
feat(workspaces): #32 - Mount workspaces into job execution environment

### DIFF
--- a/development_resources/agent_comms/chat-31.md
+++ b/development_resources/agent_comms/chat-31.md
@@ -1,0 +1,21 @@
+---
+**Agent:** CLAUDE
+**Timestamp:** 2025-10-07T00:30:00Z
+**User Prompt:** Implement temporary workspace creation and cleanup for each flow run.
+**Summary of Actions:**
+- Read and analyzed flow.rs to understand Workspace struct definition
+- Switched to develop branch and created feature/31-temp-workspaces
+- Modified orchestrator.rs imports to add fs and PathBuf (line 13-15)
+- Added create_workspace_directories() method to FlowOrchestrator (lines 65-89)
+- Modified execute() to create workspaces at start and use cleanup guard (lines 44-63)
+- Implemented WorkspaceCleanupGuard struct with Drop trait for automatic cleanup (lines 456-473)
+- Creates unique temp directory: /tmp/ferri-workspaces/{flow-name}-{timestamp}
+- Creates subdirectories for each workspace in spec.workspaces
+- Added test_workspace_creation_and_cleanup to verify functionality (lines 657-719)
+- Ran cargo build and cargo test - all tests pass
+- Committed changes with message "feat(workspaces): #31 - Implement temporary workspace creation and cleanup"
+- Pushed feature branch to origin
+- Created PR #39 targeting develop branch
+- Updated issue #31 with PR link and completion comment
+- Unassigned self from issue #31
+**Final State:** Implementation complete. PR #39 created and ready for review. Workspaces are created on flow start and automatically cleaned up. All tests passing.


### PR DESCRIPTION
## Summary
- Implements workspace mounting via environment variables
- Steps can now access workspaces defined in flow spec
- Each workspace is exposed as `FERRI_WORKSPACE_<NAME>` env var pointing to workspace directory
- Validates workspace names against flow spec definition

## Implementation Details
- Added `build_workspace_paths()` to create name-to-path mapping
- Modified execution chain to thread workspace_paths through:
  - `execute() → execute_wave() → execute_job() → execute_step() → execute_run_step()`
- In `execute_run_step()`, sets env vars for each workspace in step.workspaces
- Environment variable naming: workspace "data" → `FERRI_WORKSPACE_DATA`
- Returns error if step references undefined workspace

## Dependencies
- Builds on #31 (workspace creation) - requires that PR to be merged first

## Test Plan
- [x] Added `test_workspace_paths_mapping` to verify path mapping logic
- [x] All existing orchestrator tests pass
- [x] Build succeeds with no new warnings

## Usage Example
```yaml
spec:
  workspaces:
    - name: data
  jobs:
    process:
      steps:
        - name: Read data
          workspaces:
            - name: data
          run: |
            echo "Workspace is at: $FERRI_WORKSPACE_DATA"
            ls $FERRI_WORKSPACE_DATA
```

Closes #32